### PR TITLE
Bump jackson-databind to v2.9.7

### DIFF
--- a/project.gradle
+++ b/project.gradle
@@ -29,7 +29,7 @@ targetCompatibility = "1.6"; // defaults to sourceCompatibility
  * List of dependencies
  */
 dependencies {
-    compile(group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.2.3");
+    compile(group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.7");
     compile(group: "com.google.guava", name: "guava", version: "16.0.1");
     compile(group: "com.github.fge", name: "msg-simple", version: "1.1");
     compile(group: "com.google.code.findbugs", name: "jsr305", version: "2.0.1");


### PR DESCRIPTION
The current version 2.2.3 has a CVE on it and needs to be updated

https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31507

* https://cwe.mitre.org/data/definitions/502.html
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7525