### PR TITLE
Removed Guava, bump Gradle and all deps.

### DIFF
--- a/project.gradle
+++ b/project.gradle
@@ -30,9 +30,8 @@ targetCompatibility = JavaVersion.VERSION_1_7; // defaults to sourceCompatibilit
  */
 dependencies {
     implementation(group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.9");
-    implementation(group: "com.google.guava", name: "guava", version: "28.1-android");
     implementation(group: "com.github.java-json-tools", name: "msg-simple", version: "1.2-SNAPSHOT");
-    implementation(group: "com.google.code.findbugs", name: "jsr305", version: "2.0.1");
+    implementation(group: "com.google.code.findbugs", name: "jsr305", version: "3.0.2");
     testImplementation(group: "org.testng", name: "testng", version: "6.8.7") {
         exclude(group: "junit", module: "junit");
         exclude(group: "org.beanshell", module: "bsh");
@@ -49,9 +48,8 @@ javadoc {
             addStringOption("-release", "7");
         }
         links("https://docs.oracle.com/javase/7/docs/api/");
-        links("https://www.javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.1/");
-        links("https://fasterxml.github.io/jackson-databind/javadoc/2.2.0/");
-        links("https://www.javadoc.io/doc/com.google.guava/guava/28.1-android/");
+        links("https://www.javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.2/");
+        links("https://fasterxml.github.io/jackson-databind/javadoc/2.9/");
         links("https://java-json-tools.github.io/msg-simple/");
     }
 }

--- a/src/main/java/com/github/fge/jackson/JacksonUtils.java
+++ b/src/main/java/com/github/fge/jackson/JacksonUtils.java
@@ -29,10 +29,11 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.google.common.collect.Maps;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -94,11 +95,11 @@ public final class JacksonUtils
      */
     public static Map<String, JsonNode> asMap(final JsonNode node)
     {
-        final Map<String, JsonNode> ret = Maps.newHashMap();
         if (!node.isObject())
-            return ret;
+            return Collections.emptyMap();
 
         final Iterator<Map.Entry<String, JsonNode>> iterator = node.fields();
+        final Map<String, JsonNode> ret = new HashMap<>();
 
         Map.Entry<String, JsonNode> entry;
 
@@ -107,7 +108,7 @@ public final class JacksonUtils
             ret.put(entry.getKey(), entry.getValue());
         }
 
-        return ret;
+        return Collections.unmodifiableMap(ret);
     }
 
     /**

--- a/src/main/java/com/github/fge/jackson/JsonLoader.java
+++ b/src/main/java/com/github/fge/jackson/JsonLoader.java
@@ -20,11 +20,8 @@
 package com.github.fge.jackson;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.Preconditions;
-import com.google.common.io.Closer;
 
 import javax.annotation.Nonnull;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -74,48 +71,42 @@ public final class JsonLoader
     public static JsonNode fromResource(@Nonnull final String resource)
         throws IOException
     {
-        Preconditions.checkNotNull(resource);
-        Preconditions.checkArgument(resource.startsWith("/"),
-            "resource path does not start with a '/'");
+        if (resource == null) {
+            throw new NullPointerException();
+        }
+        if (!resource.startsWith("/")) {
+            throw new IllegalArgumentException("resource path does not start with a '/'");
+        }
         URL url;
         url = JsonLoader.class.getResource(resource);
         if (url == null) {
-            final ClassLoader classLoader = firstNonNull(
-                Thread.currentThread().getContextClassLoader(),
-                JsonLoader.class.getClassLoader()
-            );
+            final ClassLoader classLoader;
+            if (Thread.currentThread().getContextClassLoader() != null) {
+                classLoader = Thread.currentThread().getContextClassLoader();
+            } else if (JsonLoader.class.getClassLoader() != null) {
+                classLoader = JsonLoader.class.getClassLoader();
+            } else {
+                throw new NullPointerException();
+            }
             final String s = INITIAL_SLASH.matcher(resource).replaceFirst("");
             url = classLoader.getResource(s);
         }
         if (url == null)
             throw new IOException("resource " + resource + " not found");
 
-        final Closer closer = Closer.create();
         final JsonNode ret;
-        final InputStream in;
+        InputStream in = null;
 
         try {
-            in = closer.register(url.openStream());
+            in = url.openStream();
             ret = READER.fromInputStream(in);
         } finally {
-            closer.close();
+            if (in != null) {
+                in.close();
+            }
         }
 
         return ret;
-    }
-
-    /**
-     * Returns the first non-null parameter.
-     *
-     * Implementation note: Avoids the Guava method of the same name, to mitigate 'Dependency Hell'.
-     * This can be replaced by {@code MoreObjects.firstNonNull} when moving to Guava >= 18.0
-     * (Tip: Guava 20 seems like a good choice if Java 6 support is still necessary.)
-     *
-     * @throws NullPointerException if both are null.
-     */
-    private static ClassLoader firstNonNull(ClassLoader first, ClassLoader second)
-    {
-        return first != null ? first : Preconditions.checkNotNull(second);
     }
 
     /**
@@ -141,15 +132,16 @@ public final class JsonLoader
     public static JsonNode fromPath(final String path)
         throws IOException
     {
-        final Closer closer = Closer.create();
         final JsonNode ret;
-        final FileInputStream in;
+        FileInputStream in = null;
 
         try {
-            in = closer.register(new FileInputStream(path));
+            in = new FileInputStream(path);
             ret = READER.fromInputStream(in);
         } finally {
-            closer.close();
+            if (in != null) {
+                in.close();
+            }
         }
 
         return ret;
@@ -166,15 +158,16 @@ public final class JsonLoader
     public static JsonNode fromFile(final File file)
         throws IOException
     {
-        final Closer closer = Closer.create();
         final JsonNode ret;
-        final FileInputStream in;
+        FileInputStream in = null;
 
         try {
-            in = closer.register(new FileInputStream(file));
+            in = new FileInputStream(file);
             ret = READER.fromInputStream(in);
         } finally {
-            closer.close();
+            if (in != null) {
+                in.close();
+            }
         }
 
         return ret;

--- a/src/main/java/com/github/fge/jackson/JsonNodeReader.java
+++ b/src/main/java/com/github/fge/jackson/JsonNodeReader.java
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.github.fge.Builder;
 import com.github.fge.msgsimple.bundle.MessageBundle;
 import com.github.fge.msgsimple.bundle.PropertiesBundle;
-import com.google.common.io.Closer;
 
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
@@ -93,16 +92,20 @@ public final class JsonNodeReader
     public JsonNode fromInputStream(final InputStream in)
         throws IOException
     {
-        final Closer closer = Closer.create();
-        final JsonParser parser;
-        final MappingIterator<JsonNode> iterator;
+        JsonParser parser = null;
+        MappingIterator<JsonNode> iterator = null;
 
         try {
-            parser = closer.register(reader.getFactory().createParser(in));
+            parser = reader.getFactory().createParser(in);
             iterator = reader.readValues(parser);
-            return readNode(closer.register(iterator));
+            return readNode(iterator);
         } finally {
-            closer.close();
+            if (parser != null) {
+                parser.close();
+            }
+            if (iterator != null) {
+                iterator.close();
+            }
         }
     }
 
@@ -117,16 +120,20 @@ public final class JsonNodeReader
     public JsonNode fromReader(final Reader r)
         throws IOException
     {
-        final Closer closer = Closer.create();
-        final JsonParser parser;
-        final MappingIterator<JsonNode> iterator;
+        JsonParser parser = null;
+        MappingIterator<JsonNode> iterator = null;
 
         try {
-            parser = closer.register(reader.getFactory().createParser(r));
+            parser = reader.getFactory().createParser(r);
             iterator = reader.readValues(parser);
-            return readNode(closer.register(iterator));
+            return readNode(iterator);
         } finally {
-            closer.close();
+            if (parser != null) {
+                parser.close();
+            }
+            if (iterator != null) {
+                iterator.close();
+            }
         }
     }
 

--- a/src/main/java/com/github/fge/jackson/JsonNumEquals.java
+++ b/src/main/java/com/github/fge/jackson/JsonNumEquals.java
@@ -20,15 +20,15 @@
 package com.github.fge.jackson;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.Equivalence;
-import com.google.common.collect.Sets;
+import com.github.fge.jackson.com.google.common.base.Equivalence;
 
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
 /**
- * An {@link Equivalence} strategy for JSON Schema equality
+ * An {@code com.google.common.base.Equivalence} like strategy for JSON Schema equality
  *
  * <p>{@link JsonNode} does a pretty good job of obeying the  {@link
  * Object#equals(Object) equals()}/{@link Object#hashCode() hashCode()}
@@ -183,13 +183,32 @@ public final class JsonNumEquals
         /*
          * Grab the key set from the first node
          */
-        final Set<String> keys = Sets.newHashSet(a.fieldNames());
+        final Set<String> keys = new HashSet<>();
+        Iterator<String> iterator1 = a.fieldNames();
+        while (iterator1.hasNext()) {
+            final String next = iterator1.next();
+            if (next != null) {
+                keys.add(next);
+            } else {
+                throw new NullPointerException();
+            }
+        }
 
         /*
          * Grab the key set from the second node, and see if both sets are the
          * same. If not, objects are not equal, no need to check for children.
          */
-        final Set<String> set = Sets.newHashSet(b.fieldNames());
+        final Set<String> set = new HashSet<>();
+        Iterator<String> iterator2 = b.fieldNames();
+        while (iterator2.hasNext()) {
+            final String next = iterator2.next();
+            if (next != null) {
+            set.add(next);
+            } else {
+                throw new NullPointerException();
+            }
+        }
+
         if (!set.equals(keys))
             return false;
 

--- a/src/main/java/com/github/fge/jackson/NodeType.java
+++ b/src/main/java/com/github/fge/jackson/NodeType.java
@@ -22,10 +22,10 @@ package com.github.fge.jackson;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.MissingNode;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 
+import java.util.Collections;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -86,7 +86,7 @@ public enum NodeType
      * #getNodeType(JsonNode)})
      */
     private static final Map<JsonToken, NodeType> TOKEN_MAP
-        = new EnumMap<JsonToken, NodeType>(JsonToken.class);
+        = new EnumMap<>(JsonToken.class);
 
     static {
         TOKEN_MAP.put(JsonToken.START_ARRAY, ARRAY);
@@ -98,13 +98,13 @@ public enum NodeType
         TOKEN_MAP.put(JsonToken.START_OBJECT, OBJECT);
         TOKEN_MAP.put(JsonToken.VALUE_STRING, STRING);
 
-        final ImmutableMap.Builder<String, NodeType> builder
-            = ImmutableMap.builder();
+        final Map<String, NodeType> builder
+            = new HashMap<>();
 
         for (final NodeType type: NodeType.values())
             builder.put(type.name, type);
 
-        NAME_MAP = builder.build();
+        NAME_MAP = Collections.unmodifiableMap(builder);
     }
 
     NodeType(final String name)
@@ -140,8 +140,9 @@ public enum NodeType
     {
         final JsonToken token = node.asToken();
         final NodeType ret = TOKEN_MAP.get(token);
-
-        Preconditions.checkNotNull(ret, "unhandled token type " + token);
+        if (ret == null) {
+            throw new NullPointerException("unhandled token type " + token);
+        }
 
         return ret;
     }

--- a/src/main/java/com/github/fge/jackson/com/google/common/base/Equivalence.java
+++ b/src/main/java/com/github/fge/jackson/com/google/common/base/Equivalence.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright (C) 2010 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.fge.jackson.com.google.common.base;
+
+import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * A strategy for determining whether two instances are considered equivalent. Examples of
+ * equivalences are the {@linkplain #identity() identity equivalence} and {@linkplain #equals equals
+ * equivalence}.
+ *
+ * @author Bob Lee
+ * @author Ben Yu
+ * @author Gregory Kick
+ * @author <a href="mailto:25544967+soberich@users.noreply.github.com">soberich</a> on 29-Nov-18
+ */
+public abstract class Equivalence<T> {
+    /**
+     * Constructor for use by subclasses.
+     */
+    protected Equivalence() {}
+
+    /**
+     * Returns {@code true} if the given objects are considered equivalent.
+     *
+     * <p>The {@code equivalent} method implements an equivalence relation on object references:
+     *
+     * <ul>
+     * <li>It is <i>reflexive</i>: for any reference {@code x}, including null, {@code
+     *     equivalent(x, x)} returns {@code true}.
+     * <li>It is <i>symmetric</i>: for any references {@code x} and {@code y}, {@code
+     *     equivalent(x, y) == equivalent(y, x)}.
+     * <li>It is <i>transitive</i>: for any references {@code x}, {@code y}, and {@code z}, if
+     *     {@code equivalent(x, y)} returns {@code true} and {@code equivalent(y, z)} returns {@code
+     *     true}, then {@code equivalent(x, z)} returns {@code true}.
+     * <li>It is <i>consistent</i>: for any references {@code x} and {@code y}, multiple invocations
+     *     of {@code equivalent(x, y)} consistently return {@code true} or consistently return {@code
+     *     false} (provided that neither {@code x} nor {@code y} is modified).
+     * </ul>
+     */
+    public final boolean equivalent(@Nullable T a, @Nullable T b) {
+        if (a == b) {
+            return true;
+        }
+        if (a == null || b == null) {
+            return false;
+        }
+        return doEquivalent(a, b);
+    }
+
+    /**
+     * Returns {@code true} if {@code a} and {@code b} are considered equivalent.
+     *
+     * <p>Called by {@link #equivalent}. {@code a} and {@code b} are not the same
+     * object and are not nulls.
+     */
+    protected abstract boolean doEquivalent(T a, T b);
+
+    /**
+     * Returns a hash code for {@code t}.
+     *
+     * <p>The {@code hash} has the following properties:
+     * <ul>
+     * <li>It is <i>consistent</i>: for any reference {@code x}, multiple invocations of
+     *     {@code hash(x}} consistently return the same value provided {@code x} remains unchanged
+     *     according to the definition of the equivalence. The hash need not remain consistent from
+     *     one execution of an application to another execution of the same application.
+     * <li>It is <i>distributable across equivalence</i>: for any references {@code x} and {@code y},
+     *     if {@code equivalent(x, y)}, then {@code hash(x) == hash(y)}. It is <i>not</i> necessary
+     *     that the hash be distributable across <i>inequivalence</i>. If {@code equivalence(x, y)}
+     *     is false, {@code hash(x) == hash(y)} may still be true.
+     * <li>{@code hash(null)} is {@code 0}.
+     * </ul>
+     */
+    public final int hash(@Nullable T t) {
+        if (t == null) {
+            return 0;
+        }
+        return doHash(t);
+    }
+
+    /**
+     * Returns a hash code for non-null object {@code t}.
+     *
+     * <p>Called by {@link #hash}.
+     */
+    protected abstract int doHash(T t);
+
+    /**
+     * Returns a new equivalence relation for {@code F} which evaluates equivalence by first applying
+     * {@code function} to the argument, then evaluating using {@code this}. That is, for any pair of
+     * non-null objects {@code x} and {@code y}, {@code
+     * equivalence.onResultOf(function).equivalent(a, b)} is true if and only if {@code
+     * equivalence.equivalent(function.apply(a), function.apply(b))} is true.
+     *
+     * <p>For example:
+     *
+     * <pre>   {@code
+     *    Equivalence<Person> SAME_AGE = Equivalence.equals().onResultOf(GET_PERSON_AGE);}</pre>
+     *
+     * <p>{@code function} will never be invoked with a null value.
+     *
+     * <p>Note that {@code function} must be consistent according to {@code this} equivalence
+     * relation. That is, invoking {@code com.google.common.base.Function#apply} multiple times for a given value must return
+     * equivalent results.
+     * For example, {@code Equivalence.identity().onResultOf(Functions.toStringFunction())} is broken
+     * because it's not guaranteed that {@link Object#toString}) always returns the same string
+     * instance.
+     */
+    public final <F> Equivalence<F> onResultOf(Function<F, ? extends T> function) {
+        return new FunctionalEquivalence<>(function, this);
+    }
+
+    /**
+     * Returns a wrapper of {@code reference} that implements
+     * {@link Wrapper#equals(Object) Object.equals()} such that
+     * {@code wrap(a).equals(wrap(b))} if and only if {@code equivalent(a, b)}.
+     */
+    public final <S extends T> Wrapper<S> wrap(@Nullable S reference) {
+        return new Wrapper<S>(this, reference);
+    }
+
+    /**
+     * Wraps an object so that {@link #equals(Object)} and {@link #hashCode()} delegate to an
+     * {@link Equivalence}.
+     *
+     * <p>For example, given an {@link Equivalence} for {@link String strings} named {@code equiv}
+     * that tests equivalence using their lengths:
+     *
+     * <pre>   {@code
+     *   equiv.wrap("a").equals(equiv.wrap("b")) // true
+     *   equiv.wrap("a").equals(equiv.wrap("hello")) // false}</pre>
+     *
+     * <p>Note in particular that an equivalence wrapper is never equal to the object it wraps.
+     *
+     * <pre>   {@code
+     *   equiv.wrap(obj).equals(obj) // always false}</pre>
+     */
+    public static final class Wrapper<T> implements Serializable {
+        private final Equivalence<? super T> equivalence;
+        @Nullable private final T reference;
+
+        private Wrapper(Equivalence<? super T> equivalence, @Nullable T reference) {
+            if (equivalence == null) {
+                throw new NullPointerException();
+            }
+            this.equivalence = equivalence;
+            this.reference = reference;
+        }
+
+        /** Returns the (possibly null) reference wrapped by this instance. */
+        @Nullable public T get() {
+            return reference;
+        }
+
+        /**
+         * Returns {@code true} if {@link Equivalence#equivalent(Object, Object)} applied to the wrapped
+         * references is {@code true} and both wrappers use the {@link Object#equals(Object) same}
+         * equivalence.
+         */
+        @Override public boolean equals(@Nullable Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj instanceof Wrapper) {
+                Wrapper<?> that = (Wrapper<?>) obj; // note: not necessarily a Wrapper<T>
+
+                if (this.equivalence.equals(that.equivalence)) {
+                    /*
+                     * We'll accept that as sufficient "proof" that either equivalence should be able to
+                     * handle either reference, so it's safe to circumvent compile-time type checking.
+                     */
+                    @SuppressWarnings("unchecked")
+                    Equivalence<Object> equivalence = (Equivalence<Object>) this.equivalence;
+                    return equivalence.equivalent(this.reference, that.reference);
+                }
+            }
+            return false;
+        }
+
+        /**
+         * Returns the result of {@link Equivalence#hash(Object)} applied to the wrapped reference.
+         */
+        @Override public int hashCode() {
+            return equivalence.hash(reference);
+        }
+
+        /**
+         * Returns a string representation for this equivalence wrapper. The form of this string
+         * representation is not specified.
+         */
+        @Override public String toString() {
+            return equivalence + ".wrap(" + reference + ")";
+        }
+
+        private static final long serialVersionUID = 0;
+    }
+
+    /**
+     * Returns an equivalence over iterables based on the equivalence of their elements.  More
+     * specifically, two iterables are considered equivalent if they both contain the same number of
+     * elements, and each pair of corresponding elements is equivalent according to
+     * {@code this}.  Null iterables are equivalent to one another.
+     *
+     * <p>Note that this method performs a similar function for equivalences as {@code
+     * com.google.common.collect.Ordering#lexicographical} does for orderings.
+     */
+    public final <S extends T> Equivalence<Iterable<S>> pairwise() {
+        // Ideally, the returned equivalence would support Iterable<? extends T>. However,
+        // the need for this is so rare that it's not worth making callers deal with the ugly wildcard.
+        return new PairwiseEquivalence<>(this);
+    }
+
+    /**
+     * Returns a predicate that evaluates to true if and only if the input is
+     * equivalent to {@code target} according to this equivalence relation.
+     */
+    public final Predicate<T> equivalentTo(@Nullable T target) {
+        return new EquivalentToPredicate<>(this, target);
+    }
+
+    private static final class EquivalentToPredicate<T> implements Predicate<T>, Serializable {
+
+        private final Equivalence<T> equivalence;
+        @Nullable private final T target;
+
+        EquivalentToPredicate(Equivalence<T> equivalence, @Nullable T target) {
+            if (equivalence == null) {
+                throw new NullPointerException();
+            }
+            this.equivalence = equivalence;
+            this.target = target;
+        }
+
+        @Override public boolean apply(@Nullable T input) {
+            return equivalence.equivalent(input, target);
+        }
+
+        @Override public boolean equals(@Nullable Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj instanceof EquivalentToPredicate) {
+                EquivalentToPredicate<?> that = (EquivalentToPredicate<?>) obj;
+                return (equivalence.equals(that.equivalence)
+                        && (target == that.target)) || ((target != null) && target.equals(that.target));
+            }
+            return false;
+        }
+
+        @Override public int hashCode() {
+            return Arrays.hashCode(new Object[]{equivalence, target});
+        }
+
+        @Override public String toString() {
+            return equivalence + ".equivalentTo(" + target + ")";
+        }
+
+        private static final long serialVersionUID = 0;
+    }
+
+    /**
+     * Returns an equivalence that delegates to {@link Object#equals} and {@link Object#hashCode}.
+     * {@link Equivalence#equivalent} returns {@code true} if both values are null, or if neither
+     * value is null and {@link Object#equals} returns {@code true}. {@link Equivalence#hash} returns
+     * {@code 0} if passed a null value.
+     */
+    public static Equivalence<Object> equals() {
+        return Equals.INSTANCE;
+    }
+
+    /**
+     * Returns an equivalence that uses {@code ==} to compare values and {@link
+     * System#identityHashCode(Object)} to compute the hash code.  {@link Equivalence#equivalent}
+     * returns {@code true} if {@code a == b}, including in the case that a and b are both null.
+     */
+    public static Equivalence<Object> identity() {
+        return Identity.INSTANCE;
+    }
+
+    static final class Equals extends Equivalence<Object>
+            implements Serializable {
+
+        static final Equals INSTANCE = new Equals();
+
+        @Override protected boolean doEquivalent(Object a, Object b) {
+            return a.equals(b);
+        }
+        @Override public int doHash(Object o) {
+            return o.hashCode();
+        }
+
+        private Object readResolve() {
+            return INSTANCE;
+        }
+        private static final long serialVersionUID = 1;
+    }
+
+    static final class Identity extends Equivalence<Object>
+            implements Serializable {
+
+        static final Identity INSTANCE = new Identity();
+
+        @Override protected boolean doEquivalent(Object a, Object b) {
+            return false;
+        }
+
+        @Override protected int doHash(Object o) {
+            return System.identityHashCode(o);
+        }
+
+        private Object readResolve() {
+            return INSTANCE;
+        }
+        private static final long serialVersionUID = 1;
+    }
+}

--- a/src/main/java/com/github/fge/jackson/com/google/common/base/Function.java
+++ b/src/main/java/com/github/fge/jackson/com/google/common/base/Function.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2007 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.fge.jackson.com.google.common.base;
+
+import javax.annotation.Nullable;
+
+/**
+ * Determines an output value based on an input value.
+ *
+ * <p>The {@code com.google.common.base.Functions} class provides common functions and related utilites.
+ *
+ * <p>See the Guava User Guide article on <a href=
+ * "http://code.google.com/p/guava-libraries/wiki/FunctionalExplained">the use of {@code
+ * Function}</a>.
+ *
+ * @author Kevin Bourrillion
+ * @author <a href="mailto:25544967+soberich@users.noreply.github.com">soberich</a> on 29-Nov-18
+ * @since 1.10 (imported from Google Collections Library)
+ */
+public interface Function<F, T> {
+    /**
+     * Returns the result of applying this function to {@code input}. This method is <i>generally
+     * expected</i>, but not absolutely required, to have the following properties:
+     *
+     * <ul>
+     * <li>Its execution does not cause any observable side effects.
+     * <li>The computation is <i>consistent with equals</i>; that is, {@code com.google.common.base.Objects#equal
+     *     Objects.equal}{@code (a, b)} implies that {@code Objects.equal(function.apply(a),
+     *     function.apply(b))}.
+     * </ul>
+     *
+     * @throws NullPointerException if {@code input} is null and this function does not accept null
+     *     arguments
+     */
+    @Nullable
+    T apply(@Nullable F input);
+
+    /**
+     * Indicates whether another object is equal to this function.
+     *
+     * <p>Most implementations will have no reason to override the behavior of {@link Object#equals}.
+     * However, an implementation may also choose to return {@code true} whenever {@code object} is a
+     * {@link Function} that it considers <i>interchangeable</i> with this one. "Interchangeable"
+     * <i>typically</i> means that {@code Objects.equal(this.apply(f), that.apply(f))} is true for all
+     * {@code f} of type {@code F}. Note that a {@code false} result from this method does not imply
+     * that the functions are known <i>not</i> to be interchangeable.
+     */
+    @Override
+    boolean equals(@Nullable Object object);
+}

--- a/src/main/java/com/github/fge/jackson/com/google/common/base/FunctionalEquivalence.java
+++ b/src/main/java/com/github/fge/jackson/com/google/common/base/FunctionalEquivalence.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2011 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.github.fge.jackson.com.google.common.base;
+
+import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * Equivalence applied on functional result.
+ *
+ * @author Bob Lee
+ * @author <a href="mailto:25544967+soberich@users.noreply.github.com">soberich</a> on 29-Nov-18
+ * @since 1.11
+ */
+final class FunctionalEquivalence<F, T> extends Equivalence<F>
+        implements Serializable {
+
+    private static final long serialVersionUID = 0;
+
+    private final Function<F, ? extends T> function;
+    private final Equivalence<T> resultEquivalence;
+
+    FunctionalEquivalence(
+            Function<F, ? extends T> function, Equivalence<T> resultEquivalence) {
+        if (function == null) {
+            throw new NullPointerException();
+        }
+        this.function = function;
+        if (resultEquivalence == null) {
+            throw new NullPointerException();
+        }
+        this.resultEquivalence = resultEquivalence;
+    }
+
+    @Override protected boolean doEquivalent(F a, F b) {
+        return resultEquivalence.equivalent(function.apply(a), function.apply(b));
+    }
+
+    @Override protected int doHash(F a) {
+        return resultEquivalence.hash(function.apply(a));
+    }
+
+    @Override public boolean equals(@Nullable Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj instanceof FunctionalEquivalence) {
+            FunctionalEquivalence<?, ?> that = (FunctionalEquivalence<?, ?>) obj;
+            return function.equals(that.function)
+                    && resultEquivalence.equals(that.resultEquivalence);
+        }
+        return false;
+    }
+
+    @Override public int hashCode() {
+        return Arrays.hashCode(new Object[]{function, resultEquivalence});
+    }
+
+    @Override public String toString() {
+        return resultEquivalence + ".onResultOf(" + function + ")";
+    }
+}

--- a/src/main/java/com/github/fge/jackson/com/google/common/base/PairwiseEquivalence.java
+++ b/src/main/java/com/github/fge/jackson/com/google/common/base/PairwiseEquivalence.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2011 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.fge.jackson.com.google.common.base;
+
+import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.util.Iterator;
+
+final class PairwiseEquivalence<T> extends Equivalence<Iterable<T>>
+        implements Serializable {
+
+    final Equivalence<? super T> elementEquivalence;
+
+    PairwiseEquivalence(Equivalence<? super T> elementEquivalence) {
+        if (elementEquivalence == null) {
+            throw new NullPointerException();
+        }
+        this.elementEquivalence = elementEquivalence;
+    }
+
+    @Override
+    protected boolean doEquivalent(Iterable<T> iterableA, Iterable<T> iterableB) {
+        Iterator<T> iteratorA = iterableA.iterator();
+        Iterator<T> iteratorB = iterableB.iterator();
+
+        while (iteratorA.hasNext() && iteratorB.hasNext()) {
+            if (!elementEquivalence.equivalent(iteratorA.next(), iteratorB.next())) {
+                return false;
+            }
+        }
+
+        return !iteratorA.hasNext() && !iteratorB.hasNext();
+    }
+
+    @Override
+    protected int doHash(Iterable<T> iterable) {
+        int hash = 78721;
+        for (T element : iterable) {
+            hash = hash * 24943 + elementEquivalence.hash(element);
+        }
+        return hash;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object object) {
+        if (object instanceof PairwiseEquivalence) {
+            PairwiseEquivalence<?> that = (PairwiseEquivalence<?>) object;
+            return this.elementEquivalence.equals(that.elementEquivalence);
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return elementEquivalence.hashCode() ^ 0x46a3eb07;
+    }
+
+    @Override
+    public String toString() {
+        return elementEquivalence + ".pairwise()";
+    }
+
+    private static final long serialVersionUID = 1;
+}

--- a/src/main/java/com/github/fge/jackson/com/google/common/base/Predicate.java
+++ b/src/main/java/com/github/fge/jackson/com/google/common/base/Predicate.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2007 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.fge.jackson.com.google.common.base;
+
+import javax.annotation.Nullable;
+
+/**
+ * Determines a true or false value for a given input.
+ *
+ * <p>The {@code com.google.common.base.Predicates} class provides common predicates and related utilities.
+ *
+ * <p>See the Guava User Guide article on <a href=
+ * "http://code.google.com/p/guava-libraries/wiki/FunctionalExplained">the use of {@code
+ * Predicate}</a>.
+ *
+ * @author Kevin Bourrillion
+ * @since 2.0 (imported from Google Collections Library)
+ */
+public interface Predicate<T> {
+    /**
+     * Returns the result of applying this predicate to {@code input}. This method is <i>generally
+     * expected</i>, but not absolutely required, to have the following properties:
+     *
+     * <ul>
+     * <li>Its execution does not cause any observable side effects.
+     * <li>The computation is <i>consistent with equals</i>; that is, {@code com.google.common.base.Objects#equal
+     *     Objects.equal}{@code (a, b)} implies that {@code predicate.apply(a) ==
+     *     predicate.apply(b))}.
+     * </ul>
+     *
+     * @throws NullPointerException if {@code input} is null and this predicate does not accept null
+     *     arguments
+     */
+    boolean apply(@Nullable T input);
+
+    /**
+     * Indicates whether another object is equal to this predicate.
+     *
+     * <p>Most implementations will have no reason to override the behavior of {@link Object#equals}.
+     * However, an implementation may also choose to return {@code true} whenever {@code object} is a
+     * {@link Predicate} that it considers <i>interchangeable</i> with this one. "Interchangeable"
+     * <i>typically</i> means that {@code this.apply(t) == that.apply(t)} for all {@code t} of type
+     * {@code T}). Note that a {@code false} result from this method does not imply that the
+     * predicates are known <i>not</i> to be interchangeable.
+     */
+    @Override
+    boolean equals(@Nullable Object object);
+}

--- a/src/main/java/com/github/fge/jackson/jsonpointer/JsonPointer.java
+++ b/src/main/java/com/github/fge/jackson/jsonpointer/JsonPointer.java
@@ -22,10 +22,10 @@ package com.github.fge.jackson.jsonpointer;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.MissingNode;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
 import javax.annotation.concurrent.Immutable;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -44,7 +44,7 @@ public final class JsonPointer
      * The empty JSON Pointer
      */
     private static final JsonPointer EMPTY
-        = new JsonPointer(ImmutableList.<TokenResolver<JsonNode>>of());
+        = new JsonPointer(Collections.<TokenResolver<JsonNode>>emptyList());
 
     /**
      * Return an empty JSON Pointer
@@ -72,7 +72,7 @@ public final class JsonPointer
      */
     public static JsonPointer of(final Object first, final Object... other)
     {
-        final List<ReferenceToken> tokens = Lists.newArrayList();
+        final List<ReferenceToken> tokens = new ArrayList<>();
 
         tokens.add(ReferenceToken.fromRaw(first.toString()));
 
@@ -120,7 +120,14 @@ public final class JsonPointer
         final ReferenceToken refToken = ReferenceToken.fromRaw(raw);
         final JsonNodeResolver resolver = new JsonNodeResolver(refToken);
         final List<TokenResolver<JsonNode>> list
-            = Lists.newArrayList(tokenResolvers);
+            = new ArrayList<>();
+        for (final TokenResolver<JsonNode> tokenResolver : tokenResolvers) {
+            if (tokenResolver != null) {
+                list.add(tokenResolver);
+            } else {
+                throw new NullPointerException();
+            }
+        }
         list.add(resolver);
         return new JsonPointer(list);
     }
@@ -147,7 +154,14 @@ public final class JsonPointer
     {
         BUNDLE.checkNotNull(other, "nullInput");
         final List<TokenResolver<JsonNode>> list
-            = Lists.newArrayList(tokenResolvers);
+            = new ArrayList<>();
+        for (final TokenResolver<JsonNode> tokenResolver : tokenResolvers) {
+            if (tokenResolver != null) {
+                list.add(tokenResolver);
+            } else {
+                throw new NullPointerException();
+            }
+        }
         list.addAll(other.tokenResolvers);
         return new JsonPointer(list);
     }
@@ -177,7 +191,7 @@ public final class JsonPointer
     private static List<TokenResolver<JsonNode>> fromTokens(
         final List<ReferenceToken> tokens)
     {
-        final List<TokenResolver<JsonNode>> list = Lists.newArrayList();
+        final List<TokenResolver<JsonNode>> list = new ArrayList<>();
         for (final ReferenceToken token: tokens)
             list.add(new JsonNodeResolver(token));
         return list;

--- a/src/main/java/com/github/fge/jackson/jsonpointer/ReferenceToken.java
+++ b/src/main/java/com/github/fge/jackson/jsonpointer/ReferenceToken.java
@@ -21,10 +21,12 @@ package com.github.fge.jackson.jsonpointer;
 
 import com.github.fge.msgsimple.bundle.MessageBundle;
 import com.github.fge.msgsimple.load.MessageBundles;
-import com.google.common.collect.ImmutableList;
 
-import java.nio.CharBuffer;
 import javax.annotation.concurrent.Immutable;
+import java.nio.CharBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 
 /**
@@ -54,14 +56,14 @@ public final class ReferenceToken
     /**
      * List of encoding characters in a cooked token
      */
-    private static final ImmutableList<Character> ENCODED = ImmutableList.of('0', '1');
+    private static final List<Character> ENCODED = Collections.unmodifiableList(Arrays.asList('0', '1'));
 
     /**
      * List of sequences to encode in a raw token
      *
      * <p>This list and {@link #ENCODED} have matching indices on purpose.</p>
      */
-    private static final ImmutableList<Character> DECODED = ImmutableList.of('~', '/');
+    private static final List<Character> DECODED = Collections.unmodifiableList(Arrays.asList('~', '/'));
 
     /**
      * The cooked representation of that token

--- a/src/main/java/com/github/fge/jackson/jsonpointer/TreePointer.java
+++ b/src/main/java/com/github/fge/jackson/jsonpointer/TreePointer.java
@@ -26,12 +26,12 @@ import com.fasterxml.jackson.databind.node.MissingNode;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import com.github.fge.msgsimple.bundle.MessageBundle;
 import com.github.fge.msgsimple.load.MessageBundles;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 
+import javax.annotation.concurrent.ThreadSafe;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A pointer into a {@link TreeNode}
@@ -92,7 +92,7 @@ public abstract class TreePointer<T extends TreeNode>
         final List<TokenResolver<T>> tokenResolvers)
     {
         this.missing = missing;
-        this.tokenResolvers = ImmutableList.copyOf(tokenResolvers);
+        this.tokenResolvers = Collections.unmodifiableList(new ArrayList<>(tokenResolvers));
     }
 
     /**
@@ -206,7 +206,7 @@ public abstract class TreePointer<T extends TreeNode>
         throws JsonPointerException
     {
         String s = BUNDLE.checkNotNull(input, "nullInput");
-        final List<ReferenceToken> ret = Lists.newArrayList();
+        final List<ReferenceToken> ret = new ArrayList<>();
         String cooked;
         int index;
         char c;

--- a/src/main/java/com/github/fge/jackson/package-info.java
+++ b/src/main/java/com/github/fge/jackson/package-info.java
@@ -34,7 +34,7 @@
  * com.fasterxml.jackson.databind.DeserializationFeature#USE_BIG_DECIMAL_FOR_FLOATS}.
  * </p>
  *
- * <p>{@link com.github.fge.jackson.JsonNumEquals} is an {@link
+ * <p>{@link com.github.fge.jackson.JsonNumEquals} is an {@code
  * com.google.common.base.Equivalence} over {@link
  * com.fasterxml.jackson.databind.JsonNode} for recursive equivalence of JSON
  * number values.</p>

--- a/src/main/java/overview.html
+++ b/src/main/java/overview.html
@@ -29,7 +29,7 @@
 
 <ul>
     <li>"single" JSON text read from sources;</li>
-    <li>an {@link com.google.common.base.Equivalence} over {@link
+    <li>an {@code com.google.common.base.Equivalence} over {@link
     com.fasterxml.jackson.databind.JsonNode} for numeric JSON values;</li>
     <li>a generalized <a href="http://tools.ietf.org/html/rfc6901">JSON
     pointer</a> implementation over Jackson's {@link
@@ -63,7 +63,7 @@ com.fasterxml.jackson.databind.JsonNode}: <span style="font-family: monospace">1
 </span> and <span style="font-family: monospace">1.0</span> yield different
 types of nodes.</p>
 
-<p>This package provides an {@link com.google.common.base.Equivalence} to
+<p>This package provides an {@code com.google.common.base.Equivalence} to
 ensure that two numeric nodes are considered equivalent if their mathematical
 value is the same. See the javadoc for more information on how to use it.</p>
 

--- a/src/test/java/com/github/fge/jackson/JsonNodeReaderTest.java
+++ b/src/test/java/com/github/fge/jackson/JsonNodeReaderTest.java
@@ -24,8 +24,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.fge.msgsimple.bundle.MessageBundle;
 import com.github.fge.msgsimple.bundle.PropertiesBundle;
-import com.google.common.base.Supplier;
-import com.google.common.collect.Lists;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -35,6 +33,8 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -71,7 +71,7 @@ public final class JsonNodeReaderTest
     @DataProvider
     public Iterator<Object[]> getMalformedData()
     {
-        final List<Object[]> list = Lists.newArrayList();
+        final List<Object[]> list = new ArrayList<>();
 
         list.add(new Object[] { "", "read.noContent"});
         list.add(new Object[] { "[]{}", "read.trailingData"});
@@ -105,11 +105,7 @@ public final class JsonNodeReaderTest
             @Override
             public InputStream get()
             {
-                try {
-                    return new ByteArrayInputStream(input.getBytes("UTF-8"));
-                } catch (UnsupportedEncodingException e) {
-                    throw new RuntimeException("Unhandled exception", e);
-                }
+                return new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8));
             }
         };
     }
@@ -124,5 +120,22 @@ public final class JsonNodeReaderTest
                 return new StringReader(input);
             }
         };
+    }
+
+    /**
+     * A class that can supply objects of a single type.  Semantically, this could
+     * be a factory, generator, builder, closure, or something else entirely. No
+     * guarantees are implied by this interface.
+     *
+     * @author Harry Heymann
+     */
+    public interface Supplier<T> {
+        /**
+         * Retrieves an instance of the appropriate type. The returned object may or
+         * may not be a new instance, depending on the implementation.
+         *
+         * @return an instance of the appropriate type
+         */
+        T get();
     }
 }

--- a/src/test/java/com/github/fge/jackson/JsonNumEqualsTest.java
+++ b/src/test/java/com/github/fge/jackson/JsonNumEqualsTest.java
@@ -23,12 +23,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.Lists;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -49,7 +49,7 @@ public final class JsonNumEqualsTest
     @DataProvider
     public Iterator<Object[]> getInputs()
     {
-        final List<Object[]> list = Lists.newArrayList();
+        final List<Object[]> list = new ArrayList<>();
 
         JsonNode reference;
 

--- a/src/test/java/com/github/fge/jackson/SampleNodeProvider.java
+++ b/src/test/java/com/github/fge/jackson/SampleNodeProvider.java
@@ -21,15 +21,9 @@ package com.github.fge.jackson;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.google.common.base.Function;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 import java.math.BigDecimal;
-import java.util.EnumSet;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
 
 public final class SampleNodeProvider
 {
@@ -41,7 +35,7 @@ public final class SampleNodeProvider
     }
 
     static {
-        SAMPLE_DATA = Maps.newEnumMap(NodeType.class);
+        SAMPLE_DATA = new EnumMap<>(NodeType.class);
 
         SAMPLE_DATA.put(NodeType.ARRAY, FACTORY.arrayNode());
         SAMPLE_DATA.put(NodeType.BOOLEAN, FACTORY.booleanNode(true));
@@ -58,18 +52,15 @@ public final class SampleNodeProvider
     // differ...
     public static Iterator<Object[]> getSamples(final EnumSet<NodeType> types)
     {
-        final Map<NodeType, JsonNode> map = Maps.newEnumMap(SAMPLE_DATA);
+        final Map<NodeType, JsonNode> map = new EnumMap<>(SAMPLE_DATA);
         map.keySet().retainAll(types);
 
-        return FluentIterable.from(map.values())
-            .transform(new Function<JsonNode, Object[]>()
-            {
-                @Override
-                public Object[] apply(final JsonNode input)
-                {
-                    return new Object[] { input };
-                }
-            }).iterator();
+        final List<Object[]> samples = new ArrayList<>();
+        for (final JsonNode input : map.values()) {
+            samples.add(new Object[] { input });
+        }
+
+        return samples.iterator();
     }
 
     public static Iterator<Object[]> getSamplesExcept(
@@ -87,6 +78,6 @@ public final class SampleNodeProvider
     public static Iterator<Object[]> getSamplesExcept(final NodeType first,
         final NodeType... other)
     {
-        return getSamples(Sets.complementOf(EnumSet.of(first, other)));
+        return getSamples(EnumSet.complementOf(EnumSet.of(first, other)));
     }
 }

--- a/src/test/java/com/github/fge/jackson/jsonpointer/JsonNodeResolverTest.java
+++ b/src/test/java/com/github/fge/jackson/jsonpointer/JsonNodeResolverTest.java
@@ -26,10 +26,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.fge.jackson.JacksonUtils;
 import com.github.fge.jackson.NodeType;
 import com.github.fge.jackson.SampleNodeProvider;
-import com.google.common.collect.Lists;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -104,7 +104,7 @@ public final class JsonNodeResolverTest
     @DataProvider
     public Iterator<Object[]> invalidIndices()
     {
-        final List<Object[]> list = Lists.newArrayList();
+        final List<Object[]> list = new ArrayList<>();
 
         list.add(new Object[] { "-1" });
         list.add(new Object[] { "232398087298731987987232" });

--- a/src/test/java/com/github/fge/jackson/jsonpointer/JsonPointerTest.java
+++ b/src/test/java/com/github/fge/jackson/jsonpointer/JsonPointerTest.java
@@ -26,17 +26,13 @@ import com.github.fge.jackson.NodeType;
 import com.github.fge.jackson.SampleNodeProvider;
 import com.github.fge.msgsimple.bundle.MessageBundle;
 import com.github.fge.msgsimple.load.MessageBundles;
-import com.google.common.collect.Lists;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.EnumSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.testng.Assert.*;
 
@@ -70,7 +66,7 @@ public final class JsonPointerTest
     @DataProvider
     public Iterator<Object[]> rawPointers()
     {
-        final List<Object[]> list = Lists.newArrayList();
+        final List<Object[]> list = new ArrayList<>();
         final JsonNode testNode = testData.get("pointers");
         final Map<String, JsonNode> map = JacksonUtils.asMap(testNode);
 
@@ -93,7 +89,7 @@ public final class JsonPointerTest
     @DataProvider
     public Iterator<Object[]> uriPointers()
     {
-        final List<Object[]> list = Lists.newArrayList();
+        final List<Object[]> list = new ArrayList<>();
         final JsonNode testNode = testData.get("uris");
         final Map<String, JsonNode> map = JacksonUtils.asMap(testNode);
 
@@ -185,7 +181,7 @@ public final class JsonPointerTest
     @DataProvider
     public Iterator<Object[]> parentTestData()
     {
-        final List<Object[]> list = Lists.newArrayList();
+        final List<Object[]> list = new ArrayList<>();
 
         // Empty
         list.add(new Object[] { JsonPointer.empty(), JsonPointer.empty() });

--- a/src/test/java/com/github/fge/jackson/jsonpointer/ReferenceTokenTest.java
+++ b/src/test/java/com/github/fge/jackson/jsonpointer/ReferenceTokenTest.java
@@ -21,10 +21,11 @@ package com.github.fge.jackson.jsonpointer;
 
 import com.github.fge.msgsimple.bundle.MessageBundle;
 import com.github.fge.msgsimple.load.MessageBundles;
-import com.google.common.collect.ImmutableList;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 
 import static org.testng.Assert.*;
@@ -81,14 +82,14 @@ public final class ReferenceTokenTest
     @DataProvider
     public Iterator<Object[]> cookedRaw()
     {
-        return ImmutableList.of(
+        return Collections.unmodifiableList(Arrays.asList(
             new Object[] { "~0", "~" },
             new Object[] { "~1", "/" },
             new Object[] { "", "" },
             new Object[] { "~0user", "~user" },
             new Object[] { "foobar", "foobar" },
             new Object[] { "~1var~1lib~1mysql", "/var/lib/mysql" }
-        ).iterator();
+        )).iterator();
     }
 
     @Test(dataProvider = "cookedRaw")
@@ -106,11 +107,11 @@ public final class ReferenceTokenTest
     @DataProvider
     public Iterator<Object[]> indices()
     {
-        return ImmutableList.of(
+        return Collections.unmodifiableList(Arrays.asList(
             new Object[] { 0, "0" },
             new Object[] { -1, "-1" },
             new Object[]{ 13, "13" }
-        ).iterator();
+        )).iterator();
     }
 
     @Test(dataProvider = "indices")

--- a/src/test/java/com/github/fge/jackson/jsonpointer/TreePointerTest.java
+++ b/src/test/java/com/github/fge/jackson/jsonpointer/TreePointerTest.java
@@ -22,11 +22,9 @@ package com.github.fge.jackson.jsonpointer;
 import com.fasterxml.jackson.core.TreeNode;
 import com.github.fge.msgsimple.bundle.MessageBundle;
 import com.github.fge.msgsimple.load.MessageBundles;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import org.testng.annotations.Test;
 
-import java.util.List;
+import java.util.*;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -65,7 +63,7 @@ public final class TreePointerTest
         throws JsonPointerException
     {
         assertEquals(TreePointer.tokensFromInput(""),
-            ImmutableList.<ReferenceToken>of());
+                Collections.<ReferenceToken>emptyList());
     }
 
     @Test
@@ -73,7 +71,7 @@ public final class TreePointerTest
         throws JsonPointerException
     {
         final List<ReferenceToken> expected
-            = ImmutableList.of(ReferenceToken.fromCooked(""));
+            = Collections.singletonList(ReferenceToken.fromCooked(""));
         final List<ReferenceToken> actual = TreePointer.tokensFromInput("/");
 
         assertEquals(actual, expected);
@@ -83,11 +81,11 @@ public final class TreePointerTest
     public void tokenListRespectsOrder()
         throws JsonPointerException
     {
-        final List<ReferenceToken> expected = ImmutableList.of(
+        final List<ReferenceToken> expected = Collections.unmodifiableList(Arrays.asList(
             ReferenceToken.fromRaw("/"),
             ReferenceToken.fromRaw("~"),
             ReferenceToken.fromRaw("x")
-        );
+        ));
         final List<ReferenceToken> actual
             = TreePointer.tokensFromInput("/~1/~0/x");
 
@@ -98,11 +96,11 @@ public final class TreePointerTest
     public void tokenListAccountsForEmptyTokens()
         throws JsonPointerException
     {
-        final List<ReferenceToken> expected = ImmutableList.of(
+        final List<ReferenceToken> expected = Collections.unmodifiableList(Arrays.asList(
             ReferenceToken.fromRaw("a"),
             ReferenceToken.fromRaw(""),
             ReferenceToken.fromRaw("b")
-        );
+        ));
         final List<ReferenceToken> actual
             = TreePointer.tokensFromInput("/a//b");
 
@@ -121,7 +119,7 @@ public final class TreePointerTest
         when(token1.get(any(TreeNode.class))).thenReturn(null);
 
         final DummyPointer ptr = new DummyPointer(missing,
-            ImmutableList.of(token1, token2));
+            Collections.unmodifiableList(Arrays.asList(token1, token2)));
 
         final TreeNode node = mock(TreeNode.class);
         final TreeNode ret = ptr.get(node);
@@ -143,7 +141,7 @@ public final class TreePointerTest
         when(token1.get(any(TreeNode.class))).thenReturn(null);
 
         final DummyPointer ptr = new DummyPointer(missing,
-            ImmutableList.of(token1, token2));
+                Collections.unmodifiableList(Arrays.asList(token1, token2)));
 
         final TreeNode node = mock(TreeNode.class);
         final TreeNode ret = ptr.path(node);
@@ -156,7 +154,7 @@ public final class TreePointerTest
     @Test
     public void treePointerCanTellWhetherItIsEmpty()
     {
-        final List<TokenResolver<TreeNode>> list = Lists.newArrayList();
+        final List<TokenResolver<TreeNode>> list = new ArrayList<>();
 
         assertTrue(new DummyPointer(null, list).isEmpty());
 
@@ -170,7 +168,7 @@ public final class TreePointerTest
     @Test
     public void treeIsUnalteredWhenOriginalListIsAltered()
     {
-        final List<TokenResolver<TreeNode>> list = Lists.newArrayList();
+        final List<TokenResolver<TreeNode>> list = new ArrayList<>();
         final DummyPointer dummy = new DummyPointer(null, list);
 
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
Hi,
We really want to remove Guava as it is on of the largest deps in war though required by this dependency (and json-patch). This would ease the choice to depend or not on Guava.
Please kindly review.
No "optimizations" made. Just a plain migration with practically coping and pasting logic from Guava's methods (Guava is a great library but we just have a JAX-RS web-app and Guava is a too big contributor to classpath).

Overview.

Removed Guava
Bump gradlew to 5.0 and adjust scripts for compatibility
Builds and tests run now on Java 6-11
Bump all versions to top available.