### PR TITLE
Replace dead javadoc links with www.javadoc.io links.

### DIFF
--- a/project.gradle
+++ b/project.gradle
@@ -42,8 +42,8 @@ dependencies {
 }
 
 javadoc.options.links("http://docs.oracle.com/javase/6/docs/api/");
-javadoc.options.links("http://jsr-305.googlecode.com/svn/trunk/javadoc/");
+javadoc.options.links("http://www.javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.1/");
 javadoc.options.links("http://fasterxml.github.com/jackson-databind/javadoc/2.2.0/");
-javadoc.options.links("http://docs.guava-libraries.googlecode.com/git-history/v16.0.1/javadoc/");
+javadoc.options.links("http://www.javadoc.io/doc/com.google.guava/guava/16.0.1/");
 javadoc.options.links("http://fge.github.io/msg-simple/");
 


### PR DESCRIPTION
JSR-305 doesn't have 2.0.1 JavaDoc, it is pointing at the 3.0.1 release as the first release thereafter that does.

This fixes breakage in building JavaDoc, which is blocked in downstream project `json-schema-core` due to its integration with TravisCI