### PR TITLE
Bump Guava to 28.1-jre.

### DIFF
--- a/project.gradle
+++ b/project.gradle
@@ -30,7 +30,7 @@ targetCompatibility = JavaVersion.VERSION_1_6; // defaults to sourceCompatibilit
  */
 dependencies {
     implementation(group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.9");
-    implementation(group: "com.google.guava", name: "guava", version: "16.0.1");
+    implementation(group: "com.google.guava", name: "guava", version: "28.1-jre");
     implementation(group: "com.github.fge", name: "msg-simple", version: "1.1");
     implementation(group: "com.google.code.findbugs", name: "jsr305", version: "2.0.1");
     testImplementation(group: "org.testng", name: "testng", version: "6.8.7") {
@@ -44,6 +44,6 @@ dependencies {
 javadoc.options.links("http://docs.oracle.com/javase/6/docs/api/");
 javadoc.options.links("http://www.javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.1/");
 javadoc.options.links("http://fasterxml.github.com/jackson-databind/javadoc/2.2.0/");
-javadoc.options.links("http://www.javadoc.io/doc/com.google.guava/guava/16.0.1/");
+javadoc.options.links("http://www.javadoc.io/doc/com.google.guava/guava/28.1-jre/");
 javadoc.options.links("http://fge.github.io/msg-simple/");
 


### PR DESCRIPTION
Addresses [CVE-2018-10237](https://nvd.nist.gov/vuln/detail/CVE-2018-10237), which affects 11.0 through 24.1.1.