### PR TITLE
Downgrade Guava to 25.1-jre.

### DIFF
--- a/project.gradle
+++ b/project.gradle
@@ -30,7 +30,7 @@ targetCompatibility = JavaVersion.VERSION_1_6; // defaults to sourceCompatibilit
  */
 dependencies {
     implementation(group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.9.9");
-    implementation(group: "com.google.guava", name: "guava", version: "28.1-jre");
+    implementation(group: "com.google.guava", name: "guava", version: "25.1-jre");
     implementation(group: "com.github.fge", name: "msg-simple", version: "1.1");
     implementation(group: "com.google.code.findbugs", name: "jsr305", version: "2.0.1");
     testImplementation(group: "org.testng", name: "testng", version: "6.8.7") {


### PR DESCRIPTION
Otherwise, we run into https://github.com/java-json-tools/json-schema-core/issues/59. It still is beyond 24.1.1, which has [CVE-2018-10237](https://nvd.nist.gov/vuln/detail/CVE-2018-10237).