### PR TITLE
Add reference to jackson-core for javadoc generation.

### DIFF
--- a/project.gradle
+++ b/project.gradle
@@ -43,6 +43,7 @@ dependencies {
 
 javadoc.options.links("http://docs.oracle.com/javase/6/docs/api/");
 javadoc.options.links("http://www.javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.1/");
+javadoc.options.links("http://fasterxml.github.com/jackson-core/javadoc/2.2.0/");
 javadoc.options.links("http://fasterxml.github.com/jackson-databind/javadoc/2.2.0/");
 javadoc.options.links("http://www.javadoc.io/doc/com.google.guava/guava/28.1-jre/");
 javadoc.options.links("http://fge.github.io/msg-simple/");


### PR DESCRIPTION
Reference was added in commit a7ed2ff.