### PR TITLE
Restore JacksonUtils.asMap to returning mutable maps.

### DIFF
--- a/src/main/java/com/github/fge/jackson/JacksonUtils.java
+++ b/src/main/java/com/github/fge/jackson/JacksonUtils.java
@@ -32,7 +32,6 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -95,11 +94,11 @@ public final class JacksonUtils
      */
     public static Map<String, JsonNode> asMap(final JsonNode node)
     {
+        final Map<String, JsonNode> ret = new HashMap<>();
         if (!node.isObject())
-            return Collections.emptyMap();
+            return ret;
 
         final Iterator<Map.Entry<String, JsonNode>> iterator = node.fields();
-        final Map<String, JsonNode> ret = new HashMap<>();
 
         Map.Entry<String, JsonNode> entry;
 
@@ -108,7 +107,7 @@ public final class JacksonUtils
             ret.put(entry.getKey(), entry.getValue());
         }
 
-        return Collections.unmodifiableMap(ret);
+        return ret;
     }
 
     /**

--- a/src/test/java/com/github/fge/jackson/JacksonUtilsTest.java
+++ b/src/test/java/com/github/fge/jackson/JacksonUtilsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2014, Francis Galiegue (fgaliegue@gmail.com)
+ *
+ * This software is dual-licensed under:
+ *
+ * - the Lesser General Public License (LGPL) version 3.0 or, at your option, any
+ *   later version;
+ * - the Apache Software License (ASL) version 2.0.
+ *
+ * The text of this file and of both licenses is available at the root of this
+ * project or, if you have the jar distribution, in directory META-INF/, under
+ * the names LGPL-3.0.txt and ASL-2.0.txt respectively.
+ *
+ * Direct link to the sources:
+ *
+ * - LGPL 3.0: https://www.gnu.org/licenses/lgpl-3.0.txt
+ * - ASL 2.0: http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+
+package com.github.fge.jackson;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.testng.Assert.*;
+
+public final class JacksonUtilsTest
+{
+    private JsonNode testData;
+
+    @BeforeClass
+    public void initData()
+        throws IOException
+    {
+        testData = JsonLoader.fromResource("/testfile.json");
+    }
+
+    @Test()
+    public void asMapIsMutable() {
+        Map<String, JsonNode> map = JacksonUtils.asMap(testData.required(0));
+        map.remove("reference");
+    }
+}


### PR DESCRIPTION
This was the behavior before commit 97eeb08 and apparently several json-schema-core tests rely on this behavior. Added a test.