### PR TITLE
JsonNumEquals: fix equivalence for integer nodes

### DIFF
--- a/src/main/java/com/github/fge/jackson/JsonNumEquals.java
+++ b/src/main/java/com/github/fge/jackson/JsonNumEquals.java
@@ -167,10 +167,12 @@ public final class JsonNumEquals
     private static boolean numEquals(final JsonNode a, final JsonNode b)
     {
         /*
-         * If both numbers are integers, delegate to JsonNode.
+         * If both numbers are integers, compare integer values
          */
         if (a.isIntegralNumber() && b.isIntegralNumber())
-            return a.equals(b);
+            return (a.canConvertToLong() && b.canConvertToLong())
+                    ? a.longValue() == b.longValue()
+                    : a.bigIntegerValue().equals(b.bigIntegerValue());
 
         /*
          * Otherwise, compare decimal values.

--- a/src/test/java/com/github/fge/jackson/JsonNumEqualsTest.java
+++ b/src/test/java/com/github/fge/jackson/JsonNumEqualsTest.java
@@ -21,13 +21,18 @@ package com.github.fge.jackson;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BigIntegerNode;
+import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.ShortNode;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -58,6 +63,19 @@ public final class JsonNumEqualsTest
             for (final JsonNode node: element.get("equivalences"))
                 list.add(new Object[]{reference, node});
         }
+
+        list.add(new Object[]{new ShortNode((short) 1), new IntNode(1)});
+        list.add(new Object[]{new ShortNode((short) 1), new LongNode(1)});
+        list.add(new Object[]{new ShortNode((short) 1), new BigIntegerNode(BigInteger.ONE)});
+        list.add(new Object[]{new IntNode(1), new ShortNode((short) 1)});
+        list.add(new Object[]{new IntNode(1), new LongNode(1)});
+        list.add(new Object[]{new IntNode(1), new BigIntegerNode(BigInteger.ONE)});
+        list.add(new Object[]{new LongNode(1), new ShortNode((short) 1)});
+        list.add(new Object[]{new LongNode(1), new IntNode(1)});
+        list.add(new Object[]{new LongNode(1), new BigIntegerNode(BigInteger.ONE)});
+        list.add(new Object[]{new BigIntegerNode(BigInteger.ONE), new ShortNode((short) 1)});
+        list.add(new Object[]{new BigIntegerNode(BigInteger.ONE), new IntNode(1)});
+        list.add(new Object[]{new BigIntegerNode(BigInteger.ONE), new LongNode(1)});
 
         return list.iterator();
     }


### PR DESCRIPTION
I had superfluous changes when using [json-patch](https://github.com/java-json-tools/json-patch) that were caused by comparing an `IntNode` to a `LongNode`. I've corrected the `JsonNumEquals` class and added tests for all possible combinations.

Fixes #45.